### PR TITLE
Add error message of `go get`

### DIFF
--- a/DEBIAN_UBUNTU.md
+++ b/DEBIAN_UBUNTU.md
@@ -35,6 +35,7 @@ export GOPATH=/opt/go
 ## Compile Jobber
 ```
 $ go get github.com/dshearer/jobber
+can't load package: package github.com/dshearer/jobber: no buildable Go source files in /opt/go/src/github.com/dshearer/jobber
 $ cd /opt/go/src/github.com/dshearer/jobber
 $ make
 ```


### PR DESCRIPTION
IMHO it's more kind to show error message of `go get`. I thought I must solve the error before follow further instruction.