### PR TITLE
(#165) Bugfix: Runner proc wouldn't start when jobfile had bad perms

### DIFF
--- a/jobberrunner/job_runner_thread.go
+++ b/jobberrunner/job_runner_thread.go
@@ -10,7 +10,7 @@ import (
 )
 
 type JobRunnerThread struct {
-	running            bool
+	Running            bool
 	runRecChan         chan *jobfile.RunRec
 	mainThreadDoneChan chan interface{}
 	ctxCancel          context.CancelFunc
@@ -18,7 +18,7 @@ type JobRunnerThread struct {
 
 func NewJobRunnerThread() *JobRunnerThread {
 	jr := JobRunnerThread{
-		running:    false,
+		Running:    false,
 		runRecChan: make(chan *jobfile.RunRec),
 	}
 	close(jr.runRecChan)
@@ -31,10 +31,10 @@ func (self *JobRunnerThread) RunRecChan() <-chan *jobfile.RunRec {
 
 func (self *JobRunnerThread) Start(jobs []*jobfile.Job, shell string) {
 
-	if self.running {
+	if self.Running {
 		panic("JobRunnerThread already running.")
 	}
-	self.running = true
+	self.Running = true
 
 	self.mainThreadDoneChan = make(chan interface{})
 
@@ -87,7 +87,7 @@ func (self *JobRunnerThread) Cancel() {
 	common.Logger.Println("JobRunner: cancelling")
 	if self.ctxCancel != nil {
 		self.ctxCancel()
-		self.running = false
+		self.Running = false
 	}
 }
 

--- a/jobfile/job_file.go
+++ b/jobfile/job_file.go
@@ -51,6 +51,8 @@ func NewEmptyJobFile() *JobFile {
 	}
 }
 
+const gBadJobfilePerms os.FileMode = 0022
+
 func ShouldLoadJobfile(f *os.File, usr *user.User) (bool, error) {
 	// check jobfile's owner
 	ownsFile, err := common.UserOwnsFileF(usr, f)
@@ -67,9 +69,12 @@ func ShouldLoadJobfile(f *os.File, usr *user.User) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if stat.Mode().Perm()&0022 > 0 {
-		msg := fmt.Sprintf("Jobfile has bad permissions: %v",
-			stat.Mode().Perm())
+	if stat.Mode().Perm()&gBadJobfilePerms > 0 {
+		msg := fmt.Sprintf(
+			"Jobfile has bad permissions: %v. Problematic perms: %v",
+			stat.Mode().Perm(),
+			stat.Mode().Perm()&gBadJobfilePerms,
+		)
 		return false, &common.Error{What: msg}
 	}
 


### PR DESCRIPTION
- It now starts but does not load the jobfile.  This lets it report
the fact of the bad perms to the user.