### PR TITLE
Program result sink to redirect stdout and stderr

### DIFF
--- a/jobfile/result_sink_program.go
+++ b/jobfile/result_sink_program.go
@@ -101,5 +101,10 @@ func (self ProgramResultSink) Handle(rec RunRec) {
 			self.Path,
 			errMsg,
 		)
+	} else {
+		stdout, _ := SafeBytesToStr(execResult.Stdout)
+		stderr, _ := SafeBytesToStr(execResult.Stderr)
+		common.Logger.Print(stdout)
+		common.ErrLogger.Print(stderr)
 	}
 }


### PR DESCRIPTION
Currently the result sink program's stdout is simply thrown away. It'll be helpful to redirect stdout/stderr upon successful execution when we need the program to write some outputs to stdout/stderr, e.g. a program to read the result records, adding some metadata, then write them to stdout.