### PR TITLE
(#284) Fix "test" command for long-running jobs

### DIFF
--- a/ipc/commands.go
+++ b/ipc/commands.go
@@ -76,7 +76,7 @@ type TestCmd struct {
 }
 
 type TestCmdResp struct {
-	Result string `json:"result"`
+	UnixSocketPath string `json:"unixSocketPath"`
 	nonErrorCmdResp
 }
 

--- a/jobberrunner/cmd_test_job.go
+++ b/jobberrunner/cmd_test_job.go
@@ -12,13 +12,11 @@ func (self *JobManager) doTestCmd(cmd ipc.TestCmd) ipc.ICmdResp {
 		return ipc.NewErrorCmdResp(&common.Error{What: "No such job."})
 	}
 
-	// run the job in this thread
-	runRec := RunJob(nil, job, self.Shell, true)
-
-	// make response
-	if runRec.Err != nil {
-		return ipc.NewErrorCmdResp(runRec.Err)
+	common.Logger.Printf("Trying job %v\n", job.Name)
+	sockPath, err := self.testJobServer.Launch(job)
+	if err != nil {
+		return ipc.NewErrorCmdResp(err)
 	}
 
-	return ipc.TestCmdResp{Result: runRec.Describe()}
+	return ipc.TestCmdResp{UnixSocketPath: *sockPath}
 }

--- a/jobberrunner/ipc_server.go
+++ b/jobberrunner/ipc_server.go
@@ -12,7 +12,8 @@ import (
 )
 
 type IpcService struct {
-	cmdChan chan<- CmdContainer
+	serverType IpcServerType
+	cmdChan    chan<- CmdContainer
 }
 
 func (self *IpcService) Reload(
@@ -21,7 +22,7 @@ func (self *IpcService) Reload(
 
 	// send command
 	respChan := make(chan ipc.ICmdResp, 1)
-	self.cmdChan <- CmdContainer{cmd, respChan}
+	self.cmdChan <- CmdContainer{Cmd: cmd, RespChan: respChan, ServerType: self.serverType}
 
 	// get response
 	resp := <-respChan
@@ -42,7 +43,7 @@ func (self *IpcService) ListJobs(
 
 	// send command
 	respChan := make(chan ipc.ICmdResp, 1)
-	self.cmdChan <- CmdContainer{cmd, respChan}
+	self.cmdChan <- CmdContainer{Cmd: cmd, RespChan: respChan, ServerType: self.serverType}
 
 	// get response
 	resp := <-respChan
@@ -63,7 +64,7 @@ func (self *IpcService) Log(
 
 	// send command
 	respChan := make(chan ipc.ICmdResp, 1)
-	self.cmdChan <- CmdContainer{cmd, respChan}
+	self.cmdChan <- CmdContainer{Cmd: cmd, RespChan: respChan, ServerType: self.serverType}
 
 	// get response
 	resp := <-respChan
@@ -84,7 +85,7 @@ func (self *IpcService) Test(
 
 	// send command
 	respChan := make(chan ipc.ICmdResp, 1)
-	self.cmdChan <- CmdContainer{cmd, respChan}
+	self.cmdChan <- CmdContainer{Cmd: cmd, RespChan: respChan, ServerType: self.serverType}
 
 	// get response
 	resp := <-respChan
@@ -105,7 +106,7 @@ func (self *IpcService) Cat(
 
 	// send command
 	respChan := make(chan ipc.ICmdResp, 1)
-	self.cmdChan <- CmdContainer{cmd, respChan}
+	self.cmdChan <- CmdContainer{Cmd: cmd, RespChan: respChan, ServerType: self.serverType}
 
 	// get response
 	resp := <-respChan
@@ -126,7 +127,7 @@ func (self *IpcService) Pause(
 
 	// send command
 	respChan := make(chan ipc.ICmdResp, 1)
-	self.cmdChan <- CmdContainer{cmd, respChan}
+	self.cmdChan <- CmdContainer{Cmd: cmd, RespChan: respChan, ServerType: self.serverType}
 
 	// get response
 	resp := <-respChan
@@ -147,7 +148,7 @@ func (self *IpcService) Resume(
 
 	// send command
 	respChan := make(chan ipc.ICmdResp, 1)
-	self.cmdChan <- CmdContainer{cmd, respChan}
+	self.cmdChan <- CmdContainer{Cmd: cmd, RespChan: respChan, ServerType: self.serverType}
 
 	// get response
 	resp := <-respChan
@@ -168,7 +169,7 @@ func (self *IpcService) Init(
 
 	// send command
 	respChan := make(chan ipc.ICmdResp, 1)
-	self.cmdChan <- CmdContainer{cmd, respChan}
+	self.cmdChan <- CmdContainer{Cmd: cmd, RespChan: respChan, ServerType: self.serverType}
 
 	// get response
 	resp := <-respChan
@@ -189,7 +190,7 @@ func (self *IpcService) SetJob(
 
 	// send command
 	respChan := make(chan ipc.ICmdResp, 1)
-	self.cmdChan <- CmdContainer{cmd, respChan}
+	self.cmdChan <- CmdContainer{Cmd: cmd, RespChan: respChan, ServerType: self.serverType}
 
 	// get response
 	resp := <-respChan
@@ -210,7 +211,7 @@ func (self *IpcService) DeleteJob(
 
 	// send command
 	respChan := make(chan ipc.ICmdResp, 1)
-	self.cmdChan <- CmdContainer{cmd, respChan}
+	self.cmdChan <- CmdContainer{Cmd: cmd, RespChan: respChan, ServerType: self.serverType}
 
 	// get response
 	resp := <-respChan
@@ -253,6 +254,7 @@ type udsIpcServer struct {
 func NewUdsIpcServer(sockPath string, cmdChan chan<- CmdContainer) IpcServer {
 	server := &udsIpcServer{sockPath: sockPath}
 	server.service.cmdChan = cmdChan
+	server.service.serverType = IpcServerTypeUds
 	return server
 }
 
@@ -293,6 +295,7 @@ type inetIcpServer struct {
 func NewInetIpcServer(port uint, cmdChan chan<- CmdContainer) IpcServer {
 	server := &inetIcpServer{port: port}
 	server.service.cmdChan = cmdChan
+	server.service.serverType = IpcServerTypeInet
 	return server
 }
 

--- a/jobberrunner/job_manager.go
+++ b/jobberrunner/job_manager.go
@@ -8,15 +8,25 @@ import (
 
 	"github.com/dshearer/jobber/common"
 	"github.com/dshearer/jobber/ipc"
+	"github.com/dshearer/jobber/jobberrunner/testjob"
 	"github.com/dshearer/jobber/jobfile"
 )
 
+type IpcServerType int
+
+const (
+	IpcServerTypeUds  = 0
+	IpcServerTypeInet = iota
+)
+
 type CmdContainer struct {
-	Cmd      ipc.ICmd
-	RespChan chan<- ipc.ICmdResp
+	Cmd        ipc.ICmd
+	RespChan   chan<- ipc.ICmdResp
+	ServerType IpcServerType
 }
 
 type JobManager struct {
+	user                *user.User
 	jobfilePath         string
 	launched            bool
 	jfile               *jobfile.JobFile
@@ -25,6 +35,7 @@ type JobManager struct {
 	mainThreadCtxCancel context.CancelFunc
 	mainThreadDoneChan  chan interface{}
 	jobRunner           JobRunnerThread
+	testJobServer       *testjob.TestJobServer
 	Shell               string
 }
 
@@ -35,7 +46,7 @@ func NewJobManager(jobfilePath string) *JobManager {
 		panic(fmt.Sprintf("Failed to get current user: %v", err))
 	}
 
-	jm := JobManager{Shell: "/bin/sh"}
+	jm := JobManager{Shell: "/bin/sh", user: usr}
 	jm.jobfilePath = jobfilePath
 	tmp, err := jobfile.NewEmptyRawJobFile().Activate(usr)
 	if err != nil {
@@ -44,6 +55,11 @@ func NewJobManager(jobfilePath string) *JobManager {
 	}
 	jm.jfile = tmp
 	common.LogToStdoutStderr()
+
+	jm.mainThreadCtx, jm.mainThreadCtxCancel = context.WithCancel(context.Background())
+
+	jm.testJobServer = testjob.NewTestJobServer(jm.mainThreadCtx, jm.Shell, usr)
+
 	return &jm
 }
 
@@ -74,12 +90,6 @@ func (self *JobManager) replaceCurrJobfile(jfile *jobfile.JobFileRaw) {
 		WARNING: Don't activate new jobfile before stopping job threads. Cf. issue 288.
 	*/
 
-	// get current user
-	usr, err := user.Current()
-	if err != nil {
-		panic(fmt.Sprintf("Failed to get current user: %v", err))
-	}
-
 	// stop job-runner thread and wait for current runs to end
 	self.jobRunner.Cancel()
 	for rec := range self.jobRunner.RunRecChan() {
@@ -87,7 +97,8 @@ func (self *JobManager) replaceCurrJobfile(jfile *jobfile.JobFileRaw) {
 	}
 
 	// activate jobfile
-	self.jfile, err = jfile.Activate(usr)
+	var err error
+	self.jfile, err = jfile.Activate(self.user)
 	if err != nil {
 		common.ErrLogger.Printf("Error loading jobfile. Reloading previous one. %v\n", err)
 		self.jobRunner.Start(self.jfile.Jobs, self.Shell)
@@ -163,14 +174,8 @@ func (self *JobManager) loadJobfile() error {
 		        	   2. Return the error
 	*/
 
-	// get current user
-	usr, err := user.Current()
-	if err != nil {
-		panic(fmt.Sprintf("Failed to get current user: %v", err))
-	}
-
 	// open jobfile
-	jfile, err := self.openJobfile(self.jobfilePath, usr)
+	jfile, err := self.openJobfile(self.jobfilePath, self.user)
 
 	if err == nil || os.IsNotExist(err) {
 		if jfile == nil {
@@ -222,9 +227,8 @@ func (self *JobManager) handleRunRec(rec *jobfile.RunRec) {
 }
 
 func (self *JobManager) runMainThread() {
-	ctx, cancel :=
+	self.mainThreadCtx, self.mainThreadCtxCancel =
 		context.WithCancel(context.Background())
-	self.mainThreadCtxCancel = cancel
 
 	self.CmdChan = make(chan CmdContainer)
 	self.mainThreadDoneChan = make(chan interface{})
@@ -245,7 +249,7 @@ func (self *JobManager) runMainThread() {
 	Loop:
 		for {
 			select {
-			case <-ctx.Done():
+			case <-self.mainThreadCtx.Done():
 				break Loop
 
 			case rec, ok := <-self.jobRunner.RunRecChan():
@@ -258,7 +262,7 @@ func (self *JobManager) runMainThread() {
 			case cmd, ok := <-self.CmdChan:
 				if ok {
 					var shouldExit bool
-					cmd.RespChan <- self.doCmd(cmd.Cmd, &shouldExit)
+					cmd.RespChan <- self.doCmd(&cmd, &shouldExit)
 					if shouldExit {
 						self.mainThreadCtxCancel()
 						break Loop
@@ -279,16 +283,19 @@ func (self *JobManager) runMainThread() {
 		for rec := range self.jobRunner.RunRecChan() {
 			self.handleRunRec(rec)
 		}
+
+		// wait for "try" command threads
+		self.testJobServer.Wait()
 	}()
 }
 
 func (self *JobManager) doCmd(
-	tmpCmd ipc.ICmd,
+	tmpCmd *CmdContainer,
 	shouldExit *bool) ipc.ICmdResp { // runs in main thread
 
 	*shouldExit = false
 
-	switch cmd := tmpCmd.(type) {
+	switch cmd := tmpCmd.Cmd.(type) {
 	case ipc.ReloadCmd:
 		return self.doReloadCmd(cmd)
 
@@ -299,6 +306,9 @@ func (self *JobManager) doCmd(
 		return self.doLogCmd(cmd)
 
 	case ipc.TestCmd:
+		if tmpCmd.ServerType == IpcServerTypeInet {
+			return ipc.NewErrorCmdResp(fmt.Errorf("\"test\" is no longer supported over TCP"))
+		}
 		return self.doTestCmd(cmd)
 
 	case ipc.CatCmd:

--- a/jobberrunner/sources.mk
+++ b/jobberrunner/sources.mk
@@ -14,7 +14,9 @@ RUNNER_SOURCES := \
 	jobberrunner/job_runner_thread.go \
 	jobberrunner/main.go \
 	jobberrunner/queue.go \
-	jobberrunner/sources.mk
+	jobberrunner/sources.mk \
+	jobberrunner/testjob/test_job_server.go \
+	jobberrunner/testjob/test_job_thread.go \
 
 RUNNER_TEST_SOURCES := \
 	jobberrunner/cmd_init_test.go \

--- a/jobberrunner/testjob/test_job_server.go
+++ b/jobberrunner/testjob/test_job_server.go
@@ -1,0 +1,148 @@
+package testjob
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"os"
+	"os/user"
+	"path"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/dshearer/jobber/common"
+	"github.com/dshearer/jobber/jobfile"
+)
+
+type TestJobServer struct {
+	ctx       context.Context
+	shell     string
+	user      *user.User
+	waitGroup sync.WaitGroup
+}
+
+func NewTestJobServer(ctx context.Context, shell string, user *user.User) *TestJobServer {
+	return &TestJobServer{ctx: ctx, shell: shell, user: user}
+}
+
+func (self *TestJobServer) Wait() {
+	self.waitGroup.Wait()
+}
+
+func (self *TestJobServer) Launch(job *jobfile.Job) (*string, error) {
+	// set umask
+	oldUmask := syscall.Umask(0077)
+	defer syscall.Umask(oldUmask)
+
+	// make socket path
+	sockDir, err := ioutil.TempDir(common.PerUserDirPath(self.user), "try-*")
+	if err != nil {
+		return nil, err
+	}
+	sockPath := path.Join(sockDir, "output.sock")
+
+	// make socket
+	addr, err := net.ResolveUnixAddr("unix", sockPath)
+	if err != nil {
+		os.RemoveAll(sockDir)
+		return nil, err
+	}
+	listener, err := net.ListenUnix("unix", addr)
+	if err != nil {
+		os.RemoveAll(sockDir)
+		return nil, err
+	}
+
+	// launch thread
+	self.waitGroup.Add(1)
+	go self.serve(job, listener, sockDir)
+	return &sockPath, nil
+}
+
+func (self *TestJobServer) serve(job *jobfile.Job, listener net.Listener, sockDir string) {
+	defer os.RemoveAll(sockDir)
+	defer listener.Close()
+	defer self.waitGroup.Done()
+
+	// wait for connection or timeout
+	waitForConnCtx, waitForConnCtxCancel := context.WithTimeout(self.ctx, time.Minute)
+	defer waitForConnCtxCancel()
+	var conn net.Conn
+	var ok bool
+	select {
+	case conn, ok = <-makeConnChan(listener):
+		if !ok {
+			/* listener.Accept returned error */
+			return
+		}
+		defer conn.Close()
+
+	case <-waitForConnCtx.Done():
+		return
+	}
+
+	// launch thread to watch for cancellation (signalled by the client
+	// closing the connection)
+	subCtx, cancelSubCtx := context.WithCancel(self.ctx)
+	defer cancelSubCtx()
+	callWhenConnClosed(conn, cancelSubCtx)
+
+	// run job
+	thread := testJobThread{Stdout: conn, Stderr: conn}
+	if err := thread.Run(subCtx, job, self.shell); err != nil {
+		conn.Write([]byte(fmt.Sprintf("Failed to launch thread: %v\n", err)))
+		return
+	}
+
+	// wait for job to finish or cancellation
+	var result *jobfile.RunRec
+	select {
+	case result = <-thread.ResultChan():
+
+	case <-subCtx.Done():
+		common.Logger.Println("Job cancelled")
+		// wait for subproc to finish
+		result = <-thread.ResultChan()
+	}
+
+	// report result
+	conn.Write([]byte("\n\n"))
+	switch result.Fate {
+	case common.SubprocFateSucceeded:
+		conn.Write([]byte("Job succeeded\n"))
+	case common.SubprocFateFailed:
+		conn.Write([]byte("Job failed\n"))
+	case common.SubprocFateCancelled:
+		conn.Write([]byte("Job was cancelled\n"))
+	}
+}
+
+func makeConnChan(listener net.Listener) <-chan net.Conn {
+	connChan := make(chan net.Conn)
+	go func() {
+		defer close(connChan)
+		conn, err := listener.Accept()
+		if err != nil {
+			common.ErrLogger.Printf("Accept error: %v\n", err)
+			return
+		}
+		connChan <- conn
+	}()
+	return connChan
+}
+
+func callWhenConnClosed(conn net.Conn, cb func()) {
+	go func() {
+		var buf [1]byte
+		for {
+			_, err := conn.Read(buf[:])
+			if err == io.EOF {
+				cb()
+				return
+			}
+		}
+	}()
+}

--- a/jobberrunner/testjob/test_job_thread.go
+++ b/jobberrunner/testjob/test_job_thread.go
@@ -1,0 +1,94 @@
+package testjob
+
+import (
+	"context"
+	"io"
+	"os/exec"
+	"time"
+
+	"github.com/dshearer/jobber/common"
+	"github.com/dshearer/jobber/jobfile"
+)
+
+// testJobThread represents a thread that is spawned when the user calls the
+// "test" command. The thread runs one job one time. As the job runs, the
+// thread writes its output to given writers. When the job finishes,
+// the thread reports the result via a channel.
+type testJobThread struct {
+	Stdout io.Writer
+	Stderr io.Writer
+
+	runRecChan chan *jobfile.RunRec
+	cancelChan chan interface{}
+}
+
+// Run spawns the thread that runs the job.
+func (self *testJobThread) Run(ctx context.Context, job *jobfile.Job, shell string) error {
+	// make channels
+	self.runRecChan = make(chan *jobfile.RunRec)
+
+	// make subproc
+	cmd := exec.CommandContext(ctx, shell, "-c", job.Cmd)
+	cmd.Stdout = self.Stdout
+	cmd.Stderr = self.Stderr
+
+	// launch subproc
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go self.runThread(ctx, job, cmd)
+
+	return nil
+}
+
+func (self *testJobThread) runThread(ctx context.Context, job *jobfile.Job, cmd *exec.Cmd) {
+	rec := jobfile.RunRec{Job: job, RunTime: time.Now()}
+
+	// clean up
+	defer close(self.runRecChan)
+
+	// launch subproc
+	waitErrChan := make(chan error)
+	go func() {
+		defer close(waitErrChan)
+		waitErrChan <- cmd.Wait()
+	}()
+
+	// wait for something to happen
+	var waitErr error
+	select {
+	case waitErr = <-waitErrChan:
+		/* Subproc finished */
+		break
+
+	case <-ctx.Done():
+		// wait for subproc to finish
+		waitErr = <-waitErrChan
+		break
+	}
+
+	// report result
+	if waitErr == nil {
+		rec.Fate = common.SubprocFateSucceeded
+	} else if ctx.Err() != nil {
+		rec.Fate = common.SubprocFateCancelled
+	} else {
+		rec.Fate = common.SubprocFateFailed
+	}
+	rec.NewStatus = jobfile.JobGood
+	rec.ExecTime = time.Since(rec.RunTime)
+	self.runRecChan <- &rec
+}
+
+// ResultChan returns a channel on which the result is written.
+// If the thread is not currently running, returns a closed channel.
+//
+// Never returns nil (so it's always safe to read from the returned channel).
+func (self *testJobThread) ResultChan() <-chan *jobfile.RunRec {
+	if self.runRecChan == nil {
+		tmpChan := make(chan *jobfile.RunRec)
+		close(tmpChan)
+		return tmpChan
+	}
+	return self.runRecChan
+}


### PR DESCRIPTION
We now use a separte Unix socket to stream the job's output
as it runs.

Unfortunately, we must drop support for this command via TCP.

Closes #284