### PR TITLE
TestFileRunLog: Use temp dir for run log file

### DIFF
--- a/jobfile/file_run_log.go
+++ b/jobfile/file_run_log.go
@@ -142,7 +142,7 @@ func (self *backingFileDtor) readEntry(idx int,
 	}
 	entry, err := decodeRunLogEntry(string(buf))
 	if err != nil {
-		msg := fmt.Sprintf("Entry %v in %v is bad", idx, self.path)
+		msg := fmt.Sprintf("Entry %v in %v is bad: %v", idx, self.path, err)
 		return nil, &common.Error{What: msg, Cause: err}
 	}
 	return entry, nil
@@ -928,8 +928,10 @@ func decodeRunLogEntry(s string) (*RunLogEntry, error) {
 
 	// split string into fields
 	fields := strings.Split(s, "\t")
-	if len(fields) != 5 {
-		msg := "Not enough fields in log entry line."
+	nbrFields := 5
+	if len(fields) != nbrFields {
+		msg := fmt.Sprintf("Wrong number of fields in log entry line: %v but expected %v",
+			len(fields), nbrFields)
 		return nil, &common.Error{What: msg}
 	}
 

--- a/jobfile/run_log_test.go
+++ b/jobfile/run_log_test.go
@@ -1,12 +1,15 @@
 package jobfile
 
 import (
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
+	"io/ioutil"
 	"os"
+	"path"
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
 type RunLogEntrySorter []*RunLogEntry
@@ -205,7 +208,13 @@ func TestMemOnlyRunLog(t *testing.T) {
 }
 
 func TestFileRunLog(t *testing.T) {
-	path := "/tmp/runlog"
+	tmpDir, err := ioutil.TempDir("/tmp", "unittest-*")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	path := path.Join(tmpDir, "runlog")
 	makeRunLog := func() (RunLog, error) {
 		maxFileLen := (gLogEntryLen+1)*2 + gLogEntryLen
 		log, err := NewFileRunLog(path, maxFileLen, 3)
@@ -219,5 +228,4 @@ func TestFileRunLog(t *testing.T) {
 		return log.(*fileRunLog).debugInfo()
 	}
 	suite.Run(t, NewRunLogTestSuite(makeRunLog, debugInfo))
-	os.Remove(path)
 }


### PR DESCRIPTION
Before, the file wasn't always getting deleted, and subsequent
runs of the test would then load the entries in SetupTest.